### PR TITLE
Remove unused radius parameter in boundary force

### DIFF
--- a/src/components/Blog/posts/D3Force/bounds.js
+++ b/src/components/Blog/posts/D3Force/bounds.js
@@ -1,4 +1,4 @@
-export default function(radius) {
+export default function() {
   let nodes = []
   let strength = 1
   let padding = 0


### PR DESCRIPTION
Hi!

I'm following this example for my project. Just removing an unused parameter.

Alternatively, we could add and subtract the radius from the min and max variables, but that might conflict with the intent of the example.